### PR TITLE
Fix missing openContents.securityLevel error when unlocking keychain

### DIFF
--- a/lib/contents.coffee
+++ b/lib/contents.coffee
@@ -44,7 +44,7 @@ class Contents.Item
     !@decrypted
 
   securityLevel: ->
-    @detail().openContents.securityLevel || 'SL5'
+    @detail().openContents?.securityLevel || 'SL5'
 
   detail: ->
     return @_detail if @_detail


### PR DESCRIPTION
I get this error when I try to unlock the keychain:

```
/home/stayrad/Git/1pass/lib/contents.js:96
      return this.detail().openContents.securityLevel || 'SL5';
                                       ^
TypeError: Cannot read property 'securityLevel' of undefined
    at Item.Contents.Item.Item.securityLevel (/home/stayrad/Git/1pass/lib/contents.js:96:40)
    at Database.search (/home/stayrad/Git/1pass/lib/database.js:46:32)
    at /home/stayrad/Git/1pass/lib/app.js:58:32
    at /home/stayrad/Git/1pass/lib/app.js:104:20
    at ChildProcess.<anonymous> (/home/stayrad/Git/1pass/lib/password_server.js:27:20)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at handleMessage (child_process.js:318:12)
    at Pipe.channel.onread (child_process.js:339:9)
```

I haven't done much testing, but I'm guessing that one of the items in my keychain doesn't have the openContents property.

A simple fix would be to check that `@detail().openContents` exists before getting `@detail().openContents.securityLevel`.

I've run `make test` and it doesn't seem to cause any issues.
